### PR TITLE
Added ROS find package and ROS param commands in scn files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   nav_msgs
   roscpp
+  roslib
   rospy
   sensor_msgs
   std_srvs

--- a/include/stonefish_ros/ROSScenarioParser.h
+++ b/include/stonefish_ros/ROSScenarioParser.h
@@ -39,6 +39,9 @@ namespace sf
         ROSScenarioParser(ROSSimulationManager* sm);
 
     protected:
+        std::string substituteROSVars(const std::string& value);
+        bool replaceROSVars(XMLNode* node);
+        virtual bool PreProcess(XMLNode* root);
         virtual bool ParseRobot(XMLElement* element);
         virtual bool ParseSensor(XMLElement* element, Robot* robot);
     };

--- a/include/stonefish_ros/ROSSimulationManager.h
+++ b/include/stonefish_ros/ROSSimulationManager.h
@@ -30,6 +30,7 @@
 #include <Stonefish/core/SimulationManager.h>
 //ROS
 #include <ros/ros.h>
+#include <tf/transform_broadcaster.h>
 #include <sensor_msgs/JointState.h>
 #include <cola2_msgs/Setpoints.h>
 
@@ -42,12 +43,13 @@ namespace sf
 	{
 		Robot* robot;
 		bool servoVelocityMode;
+		bool publishBaseLinkTransform;
 		std::vector<Scalar> thrusterSetpoints;
 		std::vector<Scalar> propellerSetpoints;
 		std::map<std::string, Scalar> servoSetpoints;
 
 		ROSRobot(Robot* robot, unsigned int nThrusters, unsigned int nPropellers) 
-			: robot(robot), servoVelocityMode(true)
+			: robot(robot), servoVelocityMode(true), publishBaseLinkTransform(false)
 		{
 			thrusterSetpoints = std::vector<Scalar>(nThrusters, Scalar(0));
 			propellerSetpoints = std::vector<Scalar>(nPropellers, Scalar(0));
@@ -74,6 +76,7 @@ namespace sf
 	protected:
 		std::string scnFilePath;
 		ros::NodeHandle nh;
+		tf::TransformBroadcaster br;
 		std::map<std::string, ros::Publisher> pubs;
 		std::map<std::string, ros::Subscriber> subs;
 		std::vector<ROSRobot*> rosRobots;

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 	<build_depend>roscpp</build_depend>
+	<build_depend>roslib</build_depend>
 	<build_depend>rospy</build_depend>
 	<build_depend>message_generation</build_depend>
 	<build_depend>cola2_lib</build_depend>
@@ -24,6 +25,7 @@
 	<build_depend>Stonefish</build_depend>
 	
 	<run_depend>roscpp</run_depend>
+	<run_depend>roslib</run_depend>
 	<run_depend>rospy</run_depend>
 	<run_depend>message_runtime</run_depend>
 	<run_depend>cola2_core</run_depend>

--- a/src/ROSScenarioParser.cpp
+++ b/src/ROSScenarioParser.cpp
@@ -44,11 +44,106 @@
 #include <cola2_msgs/DVL.h>
 #include <cola2_msgs/Setpoints.h>
 
+#include <ros/package.h>
+
 namespace sf
 {
 
 ROSScenarioParser::ROSScenarioParser(ROSSimulationManager* sm) : ScenarioParser(sm)
 {
+}
+
+std::string ROSScenarioParser::substituteROSVars(const std::string& value)
+{
+    std::string replacedValue;
+
+    size_t currentPos = 0;
+    size_t startPos, endPos;
+    while ((startPos = value.find("$(", currentPos)) != std::string::npos && (endPos = value.find(")", startPos+2)) != std::string::npos)
+    {
+        replacedValue += value.substr(currentPos, startPos - currentPos);
+
+        std::string arguments = value.substr(startPos+2, endPos-startPos-2);
+        std::istringstream iss(arguments);
+        std::vector<std::string> results(std::istream_iterator<std::string>{iss},
+                                         std::istream_iterator<std::string>());
+        if (results.size() != 2)
+        {
+            ROS_ERROR("ROSScenarioParser: substitution args need to be 2, got: %s", arguments.c_str());
+            continue;
+        }
+
+        if (results[0] == "find")
+        {
+            std::string packagePath = ros::package::getPath(results[1]);
+            if (packagePath.empty())
+            {
+                ROS_ERROR("ROSScenarioParser: could not find package %s!", results[1].c_str());
+                return value;
+            }
+            replacedValue += packagePath;
+        }
+        else if (results[0] == "param")
+        {
+            std::string param;
+            // to get private params, we need to prefix ~ it seems
+            if (!results[1].empty() && results[1][0] != '~' && results[1][0] != '/')
+            {
+                results[1] = std::string("~") + results[1];
+            }
+            if (!ros::param::get(results[1], param))
+            {
+                ROS_ERROR("ROSScenarioParser: could not find parameter %s!", results[1].c_str());
+                return value;
+            }
+            replacedValue += param;
+        }
+        else 
+        {
+            ROS_ERROR("ROSScenarioParser: substitution command %s not currently supported!", results[0].c_str());
+            return value;
+        }
+
+        currentPos = endPos + 1;
+    }
+
+    replacedValue += value.substr(currentPos, value.size() - currentPos);
+
+    return replacedValue;
+}
+
+bool ROSScenarioParser::replaceROSVars(XMLNode* node)
+{
+    XMLElement* element = node->ToElement();
+    if (element != nullptr)
+    {
+        for (const tinyxml2::XMLAttribute* attr = element->FirstAttribute(); attr != nullptr; attr = attr->Next())
+        {
+            std::string value = std::string(attr->Value());
+            std::string substitutedValue = substituteROSVars(value);
+            if (substitutedValue != value)
+            {
+                ROS_INFO("Replacing %s with %s", value.c_str(), substitutedValue.c_str());
+                element->SetAttribute(attr->Name(), substitutedValue.c_str());
+            }
+
+        }
+    }
+
+    for (tinyxml2::XMLNode* child = node->FirstChild(); child != nullptr; child = child->NextSibling())
+    {
+        if(!replaceROSVars(child))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool ROSScenarioParser::PreProcess(XMLNode* root)
+{
+    return replaceROSVars(root);
 }
 
 bool ROSScenarioParser::ParseRobot(XMLElement* element)

--- a/src/ROSScenarioParser.cpp
+++ b/src/ROSScenarioParser.cpp
@@ -108,11 +108,19 @@ bool ROSScenarioParser::ParseRobot(XMLElement* element)
         }
     }
 
+    //Check if we should publish world_ned -> base_link transform
+    XMLElement* item;
+    if((item = element->FirstChildElement("ros_base_link_transforms")) != nullptr)
+    {
+        bool publishBaseLinkTransforms;
+        if (item->QueryBoolAttribute("publish", &publishBaseLinkTransforms) == XML_SUCCESS && publishBaseLinkTransforms)
+            rosRobot->publishBaseLinkTransform = true;
+    }
+
     //Save robot
     sim->AddROSRobot(rosRobot);
 
     //Generate subscribers
-    XMLElement* item;
     if((item = element->FirstChildElement("ros_subscriber")) != nullptr)
     {
         const char* topicThrust = nullptr;
@@ -137,6 +145,7 @@ bool ROSScenarioParser::ParseRobot(XMLElement* element)
         if(nServos > 0 && item->QueryStringAttribute("servos", &topicSrv) == XML_SUCCESS)
             pubs[robot->getName() + "/servos"] = nh.advertise<sensor_msgs::JointState>(std::string(topicSrv), 2);
     }
+
 
     return true;
 }

--- a/src/ROSSimulationManager.cpp
+++ b/src/ROSSimulationManager.cpp
@@ -126,6 +126,13 @@ void ROSSimulationManager::SimulationStepCompleted(Scalar timeStep)
         sensor->MarkDataOld();
     }   
 
+    //////////////////////////////////////WORLD TRANSFORMS/////////////////////////////////////////
+    for(size_t i=0; i<rosRobots.size(); ++i)
+    {
+        if (rosRobots[i]->publishBaseLinkTransform)
+            sf::ROSInterface::PublishTF(br, rosRobots[i]->robot->getTransform(), ros::Time::now(), "world_ned", rosRobots[i]->robot->getName() + "/base_link");
+    }
+
     //////////////////////////////////////SERVOS(JOINTS)/////////////////////////////////////////
     for(size_t i=0; i<rosRobots.size(); ++i)
     {


### PR DESCRIPTION
This PR depends on https://github.com/patrykcieslak/stonefish/pull/3 in stonefish. It implements the new virtual `PreProcess` method in `ROSScenarioParser` to preprocess the xml files and insert substituted ROS find package and ROS params in attribute values (not in other places). It adds the following syntax for getting package paths and ROS parameters:

*  `<mesh filename="$(find stonefish_ros)/data/girona500/hull_phy.obj" scale="1.0"/>`
*  `<robot name="$(param robot_name)" fixed="false" self_collisions="false">`

The second example allows us to configure the vehicle name in the launch file using:
```
<node name="stonefish_simulator" pkg="stonefish_ros" type="parsed_simulator" output="screen" args="$(arg simulation_data) $(arg scenario_description) $(arg simulation_rate) $(arg graphics_resolution) $(arg graphics_quality)">
    <param name="robot_name" value="$(arg robot_name)"/>
</node>
```
while the second allows us to split up our vehicle and scenario definitions, eliminating the need to copy resources into one package.

All the magic happens in the `substituteROSVars` and `replaceROSVars` methods of `ROSScenarioParser`, please look there for the details.

A possible next step could be to add arguments to the include tags to enable passing arguments between different `.scn` files. I have an idea of how to add this easily, let me know if you want to discuss this.