### PR TITLE
Added the ability to pass on <args> to <include>s. 

### DIFF
--- a/include/stonefish_ros/ROSScenarioParser.h
+++ b/include/stonefish_ros/ROSScenarioParser.h
@@ -28,6 +28,7 @@
 
 #include <Stonefish/core/ScenarioParser.h>
 #include <ros/ros.h>
+#include <map>
 
 namespace sf
 {
@@ -40,16 +41,18 @@ namespace sf
 
     protected:
         virtual bool PreProcess(XMLNode* root);
+        virtual bool PreProcess(XMLNode* root, std::map<std::string, std::string>& scenario_args);
         virtual bool ParseRobot(XMLElement* element);
         virtual bool ParseSensor(XMLElement* element, Robot* robot);
         virtual bool ParseActuator(XMLElement* element, Robot* robot);
         virtual bool ParseComm(XMLElement* element, Robot* robot = nullptr);
         virtual bool ParseContact(XMLElement* element);
 
-    private:
-        std::string SubstituteROSVars(const std::string& value);
-        bool ReplaceROSVars(XMLNode* node);
-    };
+	private:
+		std::string SubstituteROSVars(const std::string& value, std::map<std::string, std::string>& scenario_args);
+		bool ReplaceROSVars(XMLNode* node, std::map<std::string, std::string>& scenario_args);
+		bool ReplaceROSVars(XMLNode* node);
+	};
 }
 
 #endif


### PR DESCRIPTION
Companion to [this](https://github.com/patrykcieslak/stonefish/pull/8).

<arg>s in <include>s are passed down to the included files and $(param ...)s are replaced by the value of <arg>s, as defined by their name fields. If there are no args, rosparams are used instead as before.